### PR TITLE
[#10] Playback control commands

### DIFF
--- a/skills/home-assistant-music-assistant/SKILL.md
+++ b/skills/home-assistant-music-assistant/SKILL.md
@@ -169,10 +169,42 @@ Fields:
 - `score`: Relevance score (0-1)
 - Optional: `artist`, `album`, `genre`, `year`, `duration`
 
-### Play from URI (not yet implemented)
+### Playback Control
+
+Control media playback on speakers.
 
 ```bash
-ha-ma play --speaker "<name>" --uri "library://playlist/4" --enqueue replace
+# Play media
+ha-ma play --speaker media_player.living_room --uri "library://track/123"
+ha-ma play --speaker media_player.living_room --uri "library://playlist/1" --enqueue replace
+
+# Basic controls
+ha-ma pause --speaker media_player.living_room
+ha-ma stop --speaker media_player.living_room
+ha-ma next --speaker media_player.living_room
+ha-ma prev --speaker media_player.living_room
+
+# Volume (0-100)
+ha-ma volume --speaker media_player.living_room --level 50
+
+# Add to queue
+ha-ma queue --speaker media_player.living_room --uri "library://track/456"
+```
+
+Enqueue modes:
+- `play` - Play immediately (default)
+- `replace` - Replace current queue
+- `next` - Play next
+- `add` - Add to end of queue
+
+Output (JSON):
+```json
+{
+  "success": true,
+  "action": "play",
+  "speaker": "media_player.living_room",
+  "uri": "library://track/123"
+}
 ```
 
 ### Record a play event (local DB)

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -1,0 +1,117 @@
+/**
+ * Playback control for Music Assistant.
+ *
+ * Control media playback on speakers via Home Assistant service calls.
+ */
+
+import { HaClient } from "./ha-client.js";
+
+/** Enqueue mode for playback */
+export type EnqueueMode = "play" | "replace" | "next" | "add";
+
+/** Options for playing media */
+export interface PlayMediaOptions {
+  entityId: string;
+  uri: string;
+  mediaType?: string;
+  enqueue?: EnqueueMode;
+}
+
+/** Options for basic playback commands */
+export interface PlaybackOptions {
+  entityId: string;
+}
+
+/** Options for volume control */
+export interface VolumeOptions {
+  entityId: string;
+  level: number; // 0.0 to 1.0
+}
+
+/** Options for adding to queue */
+export interface QueueOptions {
+  entityId: string;
+  uri: string;
+  mediaType?: string;
+}
+
+/**
+ * Play media on a speaker.
+ */
+export async function playMedia(client: HaClient, options: PlayMediaOptions) {
+  const { entityId, uri, mediaType = "music", enqueue } = options;
+
+  const data: Record<string, unknown> = {
+    entity_id: entityId,
+    media_content_id: uri,
+    media_content_type: mediaType,
+  };
+
+  if (enqueue) {
+    data.enqueue = enqueue;
+  }
+
+  return client.callService("media_player", "play_media", data);
+}
+
+/**
+ * Pause media on a speaker.
+ */
+export async function pauseMedia(client: HaClient, options: PlaybackOptions) {
+  return client.callService("media_player", "media_pause", {
+    entity_id: options.entityId,
+  });
+}
+
+/**
+ * Stop media on a speaker.
+ */
+export async function stopMedia(client: HaClient, options: PlaybackOptions) {
+  return client.callService("media_player", "media_stop", {
+    entity_id: options.entityId,
+  });
+}
+
+/**
+ * Skip to the next track.
+ */
+export async function nextTrack(client: HaClient, options: PlaybackOptions) {
+  return client.callService("media_player", "media_next_track", {
+    entity_id: options.entityId,
+  });
+}
+
+/**
+ * Go to the previous track.
+ */
+export async function prevTrack(client: HaClient, options: PlaybackOptions) {
+  return client.callService("media_player", "media_previous_track", {
+    entity_id: options.entityId,
+  });
+}
+
+/**
+ * Set volume level on a speaker.
+ */
+export async function setVolume(client: HaClient, options: VolumeOptions) {
+  const level = Math.max(0, Math.min(1, options.level));
+
+  return client.callService("media_player", "volume_set", {
+    entity_id: options.entityId,
+    volume_level: level,
+  });
+}
+
+/**
+ * Add media to the queue.
+ */
+export async function addToQueue(client: HaClient, options: QueueOptions) {
+  const { entityId, uri, mediaType = "music" } = options;
+
+  return client.callService("media_player", "play_media", {
+    entity_id: entityId,
+    media_content_id: uri,
+    media_content_type: mediaType,
+    enqueue: "add",
+  });
+}

--- a/test/playback.test.ts
+++ b/test/playback.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test, beforeAll, afterAll } from "vitest";
+import { createServer, IncomingMessage, ServerResponse, Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { HaClient } from "../src/ha-client.js";
+import {
+  playMedia,
+  pauseMedia,
+  stopMedia,
+  nextTrack,
+  prevTrack,
+  setVolume,
+  addToQueue,
+} from "../src/playback.js";
+
+/**
+ * Integration tests for playback control.
+ * Uses a stubbed HTTP server to simulate HA REST API.
+ */
+
+// Track service calls
+const serviceCalls: Array<{ domain: string; service: string; data: unknown }> = [];
+
+function createMockServer(): Server {
+  return createServer((req: IncomingMessage, res: ServerResponse) => {
+    if (req.method === "POST" && req.url?.includes("/api/services/")) {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        try {
+          const body = Buffer.concat(chunks).toString();
+          const data = JSON.parse(body);
+
+          // Extract domain and service from URL
+          // /api/services/{domain}/{service}
+          const urlParts = req.url!.split("/");
+          const domain = urlParts[3];
+          const service = urlParts[4];
+
+          serviceCalls.push({ domain, service, data });
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ success: true }));
+        } catch {
+          res.writeHead(400);
+          res.end("Bad Request");
+        }
+      });
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("Not Found");
+  });
+}
+
+describe("playback control", () => {
+  let server: Server;
+  let haUrl: string;
+
+  beforeAll(async () => {
+    serviceCalls.length = 0;
+    server = createMockServer();
+
+    await new Promise<void>((resolve, reject) => {
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as AddressInfo;
+        haUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  test("plays media on speaker", async () => {
+    serviceCalls.length = 0;
+    const client = new HaClient({ baseUrl: haUrl, token: "test-token" });
+
+    await playMedia(client, {
+      entityId: "media_player.living_room",
+      uri: "library://track/123",
+    });
+
+    expect(serviceCalls.length).toBe(1);
+    expect(serviceCalls[0].domain).toBe("media_player");
+    expect(serviceCalls[0].service).toBe("play_media");
+    expect(serviceCalls[0].data).toMatchObject({
+      entity_id: "media_player.living_room",
+      media_content_id: "library://track/123",
+    });
+  });
+
+  test("pauses media on speaker", async () => {
+    serviceCalls.length = 0;
+    const client = new HaClient({ baseUrl: haUrl, token: "test-token" });
+
+    await pauseMedia(client, { entityId: "media_player.living_room" });
+
+    expect(serviceCalls.length).toBe(1);
+    expect(serviceCalls[0].domain).toBe("media_player");
+    expect(serviceCalls[0].service).toBe("media_pause");
+  });
+
+  test("stops media on speaker", async () => {
+    serviceCalls.length = 0;
+    const client = new HaClient({ baseUrl: haUrl, token: "test-token" });
+
+    await stopMedia(client, { entityId: "media_player.living_room" });
+
+    expect(serviceCalls.length).toBe(1);
+    expect(serviceCalls[0].service).toBe("media_stop");
+  });
+
+  test("skips to next track", async () => {
+    serviceCalls.length = 0;
+    const client = new HaClient({ baseUrl: haUrl, token: "test-token" });
+
+    await nextTrack(client, { entityId: "media_player.living_room" });
+
+    expect(serviceCalls.length).toBe(1);
+    expect(serviceCalls[0].service).toBe("media_next_track");
+  });
+
+  test("goes to previous track", async () => {
+    serviceCalls.length = 0;
+    const client = new HaClient({ baseUrl: haUrl, token: "test-token" });
+
+    await prevTrack(client, { entityId: "media_player.living_room" });
+
+    expect(serviceCalls.length).toBe(1);
+    expect(serviceCalls[0].service).toBe("media_previous_track");
+  });
+
+  test("sets volume level", async () => {
+    serviceCalls.length = 0;
+    const client = new HaClient({ baseUrl: haUrl, token: "test-token" });
+
+    await setVolume(client, { entityId: "media_player.living_room", level: 0.5 });
+
+    expect(serviceCalls.length).toBe(1);
+    expect(serviceCalls[0].service).toBe("volume_set");
+    expect(serviceCalls[0].data).toMatchObject({
+      volume_level: 0.5,
+    });
+  });
+
+  test("adds to queue", async () => {
+    serviceCalls.length = 0;
+    const client = new HaClient({ baseUrl: haUrl, token: "test-token" });
+
+    await addToQueue(client, {
+      entityId: "media_player.living_room",
+      uri: "library://track/456",
+    });
+
+    expect(serviceCalls.length).toBe(1);
+    expect(serviceCalls[0].service).toBe("play_media");
+    expect(serviceCalls[0].data).toMatchObject({
+      enqueue: "add",
+    });
+  });
+
+  test("plays with enqueue mode", async () => {
+    serviceCalls.length = 0;
+    const client = new HaClient({ baseUrl: haUrl, token: "test-token" });
+
+    await playMedia(client, {
+      entityId: "media_player.living_room",
+      uri: "library://track/789",
+      enqueue: "replace",
+    });
+
+    expect(serviceCalls[0].data).toMatchObject({
+      enqueue: "replace",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements complete playback control for Music Assistant.

## Changes
- Playback module: play, pause, stop, next, prev, volume, queue
- Uses HA media_player service calls
- CLI commands for all playback operations
- Support enqueue modes: play, replace, next, add
- Volume control (0-100 scale)
- Updated SKILL.md with documentation

## Tests
- 8 unit tests for playback functionality
- All 72 tests passing

## Acceptance Criteria
- [x] CLI: play with uri
- [x] CLI: pause, stop, next, prev
- [x] CLI: volume control
- [x] CLI: queue management
- [x] Uses HA service calls

Closes #10