### PR TITLE
[#18] Package skill for installation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Troy Kelly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: music-assistant
+description: Control Home Assistant Music Assistant - browse library, search, play, manage preferences and moods.
+version: 1.0.0
+metadata:
+  clawdbot:
+    emoji: 🎵
+    requires:
+      env:
+        - HA_URL
+        - HA_TOKEN
+---
+
+# Music Assistant Skill
+
+Control Home Assistant with Music Assistant integration - browse your music library, search for tracks, manage playback, set preferences, and create mood-based playlists.
+
+## Requirements
+
+- Home Assistant instance with [Music Assistant](https://music-assistant.io/) integration
+- `HA_URL` - Your Home Assistant URL (e.g., `https://ha.example.com`)
+- `HA_TOKEN` - Long-lived access token from Home Assistant
+
+## Commands
+
+### Speakers & Discovery
+
+```bash
+# List available media player speakers
+ha-ma speakers
+
+# Show Music Assistant configuration
+ha-ma ma-config [--cached] [--refresh]
+```
+
+### Browse Library
+
+```bash
+# Browse by type: artists, albums, tracks, playlists, radio
+ha-ma browse <type> [--parent <id>] [--limit <n>] [--offset <n>]
+
+# Examples
+ha-ma browse artists --limit 20
+ha-ma browse albums --parent "artist:123"
+ha-ma browse tracks --parent "album:456"
+```
+
+### Search
+
+```bash
+# Search for music
+ha-ma search <query> [--limit <n>] [--type <media_type>]
+
+# Examples
+ha-ma search "Beatles" --limit 10
+ha-ma search "jazz" --type artists
+```
+
+### Playback Control
+
+```bash
+# Play media on a speaker
+ha-ma play --speaker <entity_id> --uri <uri> [--enqueue <mode>]
+
+# Pause/Stop/Navigation
+ha-ma pause --speaker <entity_id>
+ha-ma stop --speaker <entity_id>
+ha-ma next --speaker <entity_id>
+ha-ma prev --speaker <entity_id>
+
+# Volume control (0-100)
+ha-ma volume --speaker <entity_id> --level <0-100>
+
+# Add to queue
+ha-ma queue --speaker <entity_id> --uri <uri>
+```
+
+Enqueue modes: `play`, `replace`, `next`, `add`
+
+### User Preferences
+
+```bash
+# Set preference for user or household
+ha-ma prefs set --user <slug> --<entity-type> <value> --score <score>
+ha-ma prefs set --household <slug> --<entity-type> <value> --score <score>
+
+# Get preferences
+ha-ma prefs get --user <slug>
+ha-ma prefs get --household <slug>
+
+# Clear specific preference
+ha-ma prefs clear --user <slug> --<entity-type> <value>
+ha-ma prefs clear --household <slug> --<entity-type> <value>
+```
+
+Entity types: `--artist`, `--album`, `--genre`, `--track`
+
+### Mood Mapping
+
+```bash
+# Create or update a mood
+ha-ma mood set --user <slug> --name <name> --genres <g1,g2> [--decades <d1,d2>] [--energy <low|medium|high>]
+ha-ma mood set --household <slug> --name <name> --genres <g1,g2> [--energy <level>]
+
+# List moods
+ha-ma mood list --user <slug>
+ha-ma mood list --household <slug>
+
+# Get specific mood
+ha-ma mood get --user <slug> --name <name>
+
+# Delete mood
+ha-ma mood delete --user <slug> --name <name>
+```
+
+### Play History
+
+```bash
+# Recent play history
+ha-ma history recent --user <slug> [--limit 20]
+
+# List listening sessions
+ha-ma history sessions --user <slug> [--limit 10]
+
+# Avoid list management
+ha-ma history avoid --user <slug> --uri <uri> [--reason <text>]
+ha-ma history unavoid --user <slug> --uri <uri>
+ha-ma history avoidlist --user <slug>
+```
+
+### Memory (Play Event Logging)
+
+```bash
+# Log a play event
+ha-ma memory log --user <slug> --speaker-entity <entity_id> --uri <uri> [--title ...] [--artist ...] [--album ...]
+
+# Recent play events
+ha-ma memory recent --user <slug> [--limit 10]
+```
+
+## Configuration
+
+Set environment variables in your OpenClaw config:
+
+```json
+{
+  "skills": {
+    "entries": {
+      "music-assistant": {
+        "env": {
+          "HA_URL": "https://your-ha-instance.com",
+          "HA_TOKEN": "your-long-lived-access-token"
+        }
+      }
+    }
+  }
+}
+```
+
+## Database
+
+The skill uses SQLite with Prisma for storing:
+- User and household preferences
+- Mood definitions
+- Play history and sessions
+- Avoid lists
+
+Database is automatically initialized on first use.

--- a/bin/ha-ma.js
+++ b/bin/ha-ma.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import "../dist/cli.js";

--- a/package.json
+++ b/package.json
@@ -1,16 +1,32 @@
 {
   "name": "openclaw-skill-music-assistant",
-  "private": true,
+  "version": "1.0.0",
+  "description": "OpenClaw skill for controlling Home Assistant Music Assistant - browse, search, play, preferences, moods",
   "type": "module",
+  "main": "dist/cli.js",
+  "types": "dist/cli.d.ts",
+  "bin": {
+    "ha-ma": "bin/ha-ma.js"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "prisma",
+    "SKILL.md"
+  ],
   "engines": {
-    "node": ">=25"
+    "node": ">=20"
   },
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json",
     "test": "pnpm build && vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "prisma:generate": "prisma generate",
-    "prisma:migrate:dev": "prisma migrate dev"
+    "prisma:migrate:dev": "prisma migrate dev",
+    "postinstall": "prisma generate",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@prisma/client": "^6.2.1",
@@ -18,8 +34,23 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "prettier": "^3.4.2",
     "prisma": "^6.2.1",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/troykelly/openclaw-skill-music-assistant.git"
+  },
+  "author": "Troy Kelly <troy@troykelly.com>",
+  "license": "MIT",
+  "keywords": [
+    "openclaw",
+    "skill",
+    "home-assistant",
+    "music-assistant",
+    "media-player",
+    "smart-home"
+  ]
 }


### PR DESCRIPTION
## Summary
Packages the skill for installation via clawdhub or npm.

## Changes
- **SKILL.md** — Full usage documentation with all CLI commands
- **package.json** — Removed `private: true`, added version (1.0.0), bin entry, main/types, files array, repository/author/license fields
- **bin/ha-ma.js** — CLI entry point
- **LICENSE** — MIT license

## Testing
- All 72 tests passing
- CLI works: `node bin/ha-ma.js` shows usage

## After Merge
Skill can be installed via:
```bash
clawdhub install troykelly/openclaw-skill-music-assistant
```

Closes #18