### PR TITLE
Add genre browsing to library browse command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,7 +68,7 @@ function usage(): never {
       "  ha-ma volume --speaker <entity_id> --level <0-100>\n" +
       "  ha-ma queue --speaker <entity_id> --uri <uri>\n" +
       "\n" +
-      "Browse types: artists, albums, tracks, playlists, radio\n" +
+      "Browse types: artists, albums, tracks, playlists, radio, genres\n" +
       "Enqueue modes: play, replace, next, add\n"
   );
   process.exit(2);
@@ -117,7 +117,7 @@ async function main() {
 
   if (cmd === "browse") {
     const mediaType = sub as BrowseMediaType | undefined;
-    const validTypes: BrowseMediaType[] = ["artists", "albums", "tracks", "playlists", "radio"];
+    const validTypes: BrowseMediaType[] = ["artists", "albums", "tracks", "playlists", "radio", "genres"];
     if (!mediaType || !validTypes.includes(mediaType)) {
       usage();
     }


### PR DESCRIPTION
## Summary

Implements Issue #27: Add genre browsing to library browse command.

## Changes

- Add `genres` as a valid `BrowseMediaType` in `src/browse.ts`
- Update CLI help text to include `genres` in browse types
- Add test for genre browsing
- Fix browse test data format to match Music Assistant API schema
- Make prisma parameter optional when `configEntryId` is provided directly

## Testing

- `ha-ma browse genres` now returns genre list from Music Assistant
- All browse tests pass including new genre test

## Notes

Pre-existing test failures in `search.test.ts` (6 tests) and `playback.test.ts` (1 test) are unrelated to this PR - they have function signature mismatches that predate this change.

Closes #27